### PR TITLE
fix: Remove LuaSnip to fix build

### DIFF
--- a/files/isengard-nvim/lua/plugins/lsp.lua
+++ b/files/isengard-nvim/lua/plugins/lsp.lua
@@ -4,5 +4,4 @@ return {
   { "neovim/nvim-lspconfig" },
   { "hrsh7th/cmp-nvim-lsp" },
   { "hrsh7th/nvim-cmp" },
-  { "L3MON4D3/LuaSnip" },
 }


### PR DESCRIPTION
Build has been failing due to: 
```
PANIC: unprotected error in call to Lua API (...S/local/share/nvim/lazy/mason.nvim/lua/mason-core/fs.lua:13: bad argument #1 to 'fs_fstat' (number expected, got nil))
```